### PR TITLE
added percent support to --setfan

### DIFF
--- a/rocm-smi
+++ b/rocm-smi
@@ -773,6 +773,8 @@ def setFanSpeed(deviceList, fan):
             continue
         fanpath = os.path.join(hwmon, 'pwm1')
         maxfan = getMaxLevel(device, 'fan')
+        if fan.endswith('%'):
+            fan = str(int((int(fan[:-1])*maxfan)/100))
         if int(fan) > maxfan:
             printLog(device, 'Unable to set fan speed to ' + fan + ' : Max Level = ' + str(maxfan))
             continue


### PR DESCRIPTION
That PR add "percent" support to fan settings: `roc-smi --setfan 50%`

Motivation: I was willing to force my fan speed to 30% using `roc-smi --setfan 30` but I almost burned them since the level range was 0..255 instead of 0..100!



