### PR TITLE
enable manual fan control before trying to set pwm

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ For convenience purposes, following is a quick excerpt:
 ```shell
 
 usage: rocm-smi [-h] [-d DEVICE] [-i] [-t] [-c] [-g] [-f] [-p] [-P] [-o] [-l] [-s] [-a] [-r]
-                [--setsclk LEVEL [LEVEL ...]] [--setmclk LEVEL [LEVEL ...]] [--setfan LEVEL]
+                [--setsclk LEVEL [LEVEL ...]] [--setmclk LEVEL [LEVEL ...]] [--resetfans] [--setfan LEVEL]
                 [--setperflevel LEVEL] [--setoverdrive %] [--setprofile # # # # #] [--resetprofile]
                 [--load FILE | --save FILE] [--autorespond RESPONSE]
+
 
 AMD ROCm System Management Interface
 
@@ -52,6 +53,7 @@ optional arguments:
   --setsclk LEVEL [LEVEL ...] Set GPU Clock Frequency Level Mask (manual)
   --setmclk LEVEL [LEVEL ...] Set GPU Memory Clock Frequency Mask (manual)
   --setfan LEVEL              Set GPU Fan Speed Level
+  --resetfans                 Reset GPU fans to automatic control
   --setperflevel LEVEL        Set PowerPlay Performance Level
   --setoverdrive %            Set GPU OverDrive level (manual|high)
   --setprofile # # # # #      Specify Compute Profile attributes (auto)

--- a/rocm-smi
+++ b/rocm-smi
@@ -83,6 +83,7 @@ valuePaths = {
     'profile' : {'prefix' : drmprefix, 'filepath' : 'pp_compute_power_profile', 'needsparse' : False},
     'fan' : {'prefix' : hwmonprefix, 'filepath' : 'pwm1', 'needsparse' : False},
     'fanmax' : {'prefix' : hwmonprefix, 'filepath' : 'pwm1_max', 'needsparse' : False},
+    'fanmode' : {'prefix' : hwmonprefix, 'filepath' : 'pwm1_enable', 'needsparse' : False},
     'temp' : {'prefix' : hwmonprefix, 'filepath' : 'temp1_input', 'needsparse' : True},
     'power' : {'prefix' : powerprefix, 'filepath' : 'amdgpu_pm_info', 'needsparse' : True}
 }
@@ -883,6 +884,7 @@ def setFanSpeed(deviceList, fan):
             RETCODE = 1
             continue
         fanpath = os.path.join(hwmon, 'pwm1')
+        modepath = os.path.join(hwmon, 'pwm1_enable')
         maxfan = getSysfsValue(device, 'fanmax')
         if not maxfan:
             printLog(device, 'Cannot get max fan speed')
@@ -892,6 +894,12 @@ def setFanSpeed(deviceList, fan):
             printLog(device, 'Unable to set fan speed to ' + fan + ' : Max Level = ' + maxfan)
             RETCODE = 1
             continue
+        if getSysfsValue(device, 'fanmode') != '1':
+            if writeToSysfs(modepath, '1'):
+                printLog(device, 'Successfully set fan control to \'manual\'')
+            else:
+                printLog(device, 'Unable to set fan control to \'manual\'')
+                continue
         if writeToSysfs(fanpath, str(fan)):
             printLog(device, 'Successfully set fan speed to Level ' + str(fan))
         else:


### PR DESCRIPTION
This fixes #18.

Was not able to update previous PR #20, as branches had changed. This one is based on [krussell/fixes](https://github.com/RadeonOpenCompute/ROC-smi/commits/krussell/fixes) and especially on commit https://github.com/RadeonOpenCompute/ROC-smi/commit/01678ca4b278a42aa3f095ed27209a4f3f216389, while also implementing a test case for `--resetfans` and updating the README

Note: the test case only checks if the sysfs values are correct, not if the fan speed is actually changing. That should be in the responsibility of the driver