### PR TITLE
Fix the number of arguments for printLog()

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ optional arguments:
   -g, --showgpuclocks         Show current GPU clock frequencies
   -f, --showfan               Show current fan speed
   -p, --showperflevel         Show current PowerPlay Performance Level
-  -P, --showpower             Show current power consumption
+  -P, --showpower             Show current Graphics ASIC power consumption
   -o, --showoverdrive         Show current OverDrive level
   -l, --showprofile           Show Compute Profile attributes
   -s, --showclkfrq            Show supported GPU and Memory Clock

--- a/rocm-smi
+++ b/rocm-smi
@@ -119,7 +119,7 @@ def getSysfsValue(device, key):
         fileValue = parseSysfsValue(key, fileValue)
 
     if fileValue == '':
-        printLog(device, 'Unable to get SysFS value: ', key)
+        printLog(device, 'Unable to get SysFS value: ' + key)
         RETCODE = 1
 
     return fileValue

--- a/rocm-smi
+++ b/rocm-smi
@@ -101,6 +101,8 @@ def getSysfsValue(device, key):
 
     if pathDict['prefix'] == hwmonprefix:
         """ HW Monitor values have a different path structure """
+        if not getHwmonFromDevice(device):
+            return None
         filePath = os.path.join(getHwmonFromDevice(device), pathDict['filepath'])
     if pathDict['prefix'] == powerprefix:
         """ Power consumption is in debugfs and has a different path structure """


### PR DESCRIPTION
This simple patch fixes the following error.

```
Traceback (most recent call last):
  File "./rocm-smi", line 1058, in <module>
    showAllConcise(deviceList)
  File "./rocm-smi", line 714, in showAllConcise
    power = getSysfsValue(device, 'power')
  File "./rocm-smi", line 122, in getSysfsValue
    printLog(device, 'Unable to get SysFS value: ', key)
TypeError: printLog() takes 2 positional arguments but 3 were given
```