### PR TITLE
Fix --setpoweroverdrive type conversion

### DIFF
--- a/rocm_smi.py
+++ b/rocm_smi.py
@@ -1081,6 +1081,11 @@ def setPowerOverDrive(deviceList, value, autoRespond):
         return
 
     confirmOutOfSpecWarning(autoRespond)
+    
+    # Value in Watt - stored early this way to avoid pythons float -> int -> str conversion after dividing a number
+    strValue = value
+    # Our Watt value converted for sysfs as microWatt
+    value = int(value) * 1000000
 
     for device in deviceList:
         if not isDPMAvailable(device):
@@ -1092,27 +1097,28 @@ def setPowerOverDrive(deviceList, value, autoRespond):
             continue
         power_cap_path = os.path.join(hwmon, 'power1_cap')
 
-        max_power_cap = str(int(getSysfsValue(device, 'power_cap_max')) / 1000000)
-        min_power_cap = str(int(getSysfsValue(device, 'power_cap_min')) / 1000000)
+        # Avoid early unnecessary conversions
+        max_power_cap = int(getSysfsValue(device, 'power_cap_max'))
+        min_power_cap = int(getSysfsValue(device, 'power_cap_min'))
 
-        if int(value) < int(min_power_cap):
-            printLog(device, 'Unable to set Power OverDrive to less than ' + min_power_cap + 'W')
+        if value < min_power_cap:
+            printLog(device, 'Unable to set Power OverDrive to less than ' + str(min_power_cap / 1000000) + 'W')
             RETCODE = 1
             return
 
-        if int(value) > int(max_power_cap):
-            printLog(device, 'Unable to set Power OverDrive to more than ' + max_power_cap + 'W')
+        if value > max_power_cap:
+            printLog(device, 'Unable to set Power OverDrive to more than ' + str(max_power_cap / 1000000) + 'W')
             RETCODE = 1
             return;
 
-        if writeToSysfs(power_cap_path, str(int(value) * 1000000)):
-            if int(value) != 0:
-                printLog(device, 'Successfully set Power OverDrive to ' + value + 'W')
+        if writeToSysfs(power_cap_path, str(value)):
+            if value != 0:
+                printLog(device, 'Successfully set Power OverDrive to ' + strValue + 'W')
             else:
                 printLog(device, 'Successfully reset Power OverDrive')
         else:
-            if int(value) != 0:
-                printLog(device, 'Unable to set Power OverDrive to ' + value + 'W')
+            if value != 0:
+                printLog(device, 'Unable to set Power OverDrive to ' + strValue + 'W')
             else:
                 printLog(device, 'Unable to reset Power OverDrive to default')
 


### PR DESCRIPTION
Here python returns the string value of getSysfsValue cast to int
then dividing by 1000000 returns a float string for min(0.0) & max(145.0) power cap
Casting those to int in the comparison breaks python rules (precision loss)
A fix would be to first cast to float and then to int - but this is bad.
```python
        max_power_cap = str(int(getSysfsValue(device, 'power_cap_max')) / 1000000)
        min_power_cap = str(int(getSysfsValue(device, 'power_cap_min')) / 1000000)

        if int(value) < int(min_power_cap):
```

Instead avoid early div by 1 000 000, the kernel already uses microWatt values,
dividing these can give floating point results which cause problems.
For example when attempting to set poweroverdrive in the prior code:

```
Traceback (most recent call last):
  File "/usr/bin/rocm-smi", line 1506, in <module>
    setPowerOverDrive(deviceList, args.setpoweroverdrive, args.autorespond)
  File "/usr/bin/rocm-smi", line 1098, in setPowerOverDrive
    if int(value) < int(min_power_cap):
ValueError: invalid literal for int() with base 10: '0.0'
```

This patch fixes this by instead setting up input value as microWatt to avoid
unnecessary conversions that may yield floats where important.
 - string output excluded.

Signed-off-by: Rigo Reddig <rigo.reddig@gmail.com>