### PR TITLE
support debug output of sysfs writes

### DIFF
--- a/rocm_smi.py
+++ b/rocm_smi.py
@@ -312,6 +312,7 @@ def writeToSysfs(fsFile, fsValue):
 def listDevices():
     """ Return a list of GPU devices."""
     devicelist = [device for device in os.listdir(drmprefix) if re.match(r'^card\d+$', device)]
+    devicelist.sort()
     return devicelist
 
 


### PR DESCRIPTION
It is very useful to know what actual writes the `rocm-smi` tool performs on
sysfs. In the future more debug output can be added for read operations as well
such that users can use the tool as an example for using the sysfs interface.

This is one of my very first times touching python code. Let me know if anything can be improved.