### PR TITLE
fixed a bug causing KeyError in setpoweroverdrive

### DIFF
--- a/rocm_smi.py
+++ b/rocm_smi.py
@@ -1393,7 +1393,7 @@ def setPowerOverDrive(deviceList, value, autoRespond):
         if not isDPMAvailable(device):
             printLog(device, 'Unable to set Power OverDrive')
             continue
-        power_cap_path = getFilePath(device, 'power1_cap')
+        power_cap_path = getFilePath(device, 'power_cap')
 
         # Avoid early unnecessary conversions
         max_power_cap = int(getSysfsValue(device, 'power_cap_max'))


### PR DESCRIPTION
[Error Log]
sudo rocm-smi --setpoweroverdrive 125
Traceback (most recent call last):
  File "/usr/bin/rocm-smi", line 1910, in <module>
    setPowerOverDrive(deviceList, args.setpoweroverdrive, args.autorespond)
  File "/usr/bin/rocm-smi", line 1396, in setPowerOverDrive
    power_cap_path = getFilePath(device, 'power1_cap')
  File "/usr/bin/rocm-smi", line 130, in getFilePath
    pathDict = valuePaths[key]
KeyError: 'power1_cap'
[FIX]
Line 1396，change `power1_cap` to `power_cap` fixed the error.