### PR TITLE
avoid strictly depending on python2 from ubuntu

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -4,7 +4,7 @@ Maintainer: Advanced Micro Devices Inc.
 Section: devel
 Priority: optional
 Version: MODULE_VERSION
-Depends: python
+Depends: python | python3
 Homepage: https://github.com/RadeonOpenCompute/ROC-smi
 Description: System Management Interface for ROCm
 

--- a/rocm-smi
+++ b/rocm-smi
@@ -1,1 +1,7 @@
-./rocm_smi.py
+#!/bin/sh -e
+
+if which python3 >/dev/null; then
+  exec python3 $(dirname $0)/rocm_smi.py
+else
+  exec python2 $(dirname $0)/rocm_smi.py
+fi


### PR DESCRIPTION
Some environment like light-weight needs python3 env only, while in the full stack of rocm, ROC-smi is the only module that is strictly depends on python2 which is not necessary.