### PR TITLE
change dependency on 'python' to 'python3'

### DIFF
--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -4,7 +4,7 @@ Maintainer: Advanced Micro Devices Inc.
 Section: devel
 Priority: optional
 Version: MODULE_VERSION
-Depends: python
+Depends: python3
 Homepage: https://github.com/RadeonOpenCompute/ROC-smi
 Description: System Management Interface for ROCm
 

--- a/rocm_smi.py
+++ b/rocm_smi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """ ROCm-SMI (System Management Interface) Tool
 
 This tool provides a user-friendly interface for manipulating


### PR DESCRIPTION
fixes #83 for Ubuntu 20.04 support